### PR TITLE
README has wrong default for --spacerdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ NEED INTERNET CONNECTION
 
 `-l`,`--proteinlen`: Protein length, need to be used together with `-P`
 
-`-d`,`--spacerdb`: Spacer blast database, choices = `phage` or `prokaryote`. Default is `prokaryote`
+`-d`,`--spacerdb`: Spacer blast database, choices = `phage` or `prokaryote`. Default is `phage`
 
 `-L`,`--flanklen`: Length of flank sequence, default is `12`
 


### PR DESCRIPTION
It seems like, by default, the BLAST searches are looking with `txid10239`, which look like it's viruses?

I've updated the documentation to reflect what seems to be the real default!